### PR TITLE
On hover link fades in and out

### DIFF
--- a/src/assets/scripts/embed.njk
+++ b/src/assets/scripts/embed.njk
@@ -56,6 +56,7 @@ class WebringBanner extends HTMLElement {
           .webring-banner a {
             color: #7b16ff;
             text-decoration: none;
+            transition: 0.5s ease;
           }
 
           .webring-banner a:hover,


### PR DESCRIPTION
This change should make the links on the embed.js fade in and out when moused over.

This is just a slight change to make it more smooth.