### PR TITLE
Inline members into polyring embed

### DIFF
--- a/src/assets/scripts/embed.njk
+++ b/src/assets/scripts/embed.njk
@@ -2,7 +2,8 @@
 permalink: 'embed.js'
 ---
 {% terser %}
-const THEME_FOLDER_URL = "https://polyring.ch/assets/themes/"
+const THEME_FOLDER_URL = "https://polyring.ch/assets/themes/";
+const MEMBERS = {% include "src/data/members.json" %};
 
 class WebringBanner extends HTMLElement {
 
@@ -20,21 +21,16 @@ class WebringBanner extends HTMLElement {
         this.ringtitle = '{{ meta.title }}';
         this.url = '{{ meta.url }}';
         this.image = this.url + '/assets/images/{{ meta.image }}';
-        this.membercount = {{ members | length}};
         this.shadowObj = this.attachShadow({ mode: 'open' });
-        
-        fetch('{{meta.dataUrl}}')
-          .then(response => response.json())
-          .then(sites => {
-            const siteIndex = sites.findIndex(
-              (site) => site.url.includes(window.location.hostname)
-            );
 
-            this.previousUrl = siteIndex < 1 ? sites[sites.length - 1].url : sites[siteIndex - 1].url;
-            this.nextUrl = siteIndex >= sites.length - 1 ? sites[0].url : sites[siteIndex + 1].url;
-            
-            this.render();
-          });
+        const siteIndex = MEMBERS.findIndex(
+          (site) => site.url.includes(window.location.hostname)
+        );
+
+        this.previousUrl = siteIndex < 1 ? MEMBERS[MEMBERS.length - 1].url : MEMBERS[siteIndex - 1].url;
+        this.nextUrl = siteIndex >= MEMBERS.length - 1 ? MEMBERS[0].url : MEMBERS[siteIndex + 1].url;
+
+        this.render();
     }
 
     static get observedAttributes() {
@@ -100,7 +96,7 @@ class WebringBanner extends HTMLElement {
             height: 70px;
             margin-right: 1rem;
             border-radius: 50%;
-          }
+          } 
 
           .webring-banner_text {
             line-height:0%;
@@ -177,7 +173,7 @@ class WebringBanner extends HTMLElement {
                 <h3 class="webring-banner__title">
                   <a href="${this.url}">${this.ringtitle}</a>
                 </h3>
-                <span>A webring with ${this.membercount} members</span>
+                <span>A webring with ${MEMBERS.length} members</span>
               </div>
               <a class="webring-banner__info" href="https://en.wikipedia.org/wiki/Webring" title="What's this?">?</a>
             </div>

--- a/src/data/meta.json
+++ b/src/data/meta.json
@@ -3,6 +3,5 @@
     "description": "The webring for content produced by members of ETH Zurich, a university in Switzerland.",
     "image": "polyring_icon.min.svg",
     "url": "https://polyring.ch",
-    "dataUrl": "https://polyring.ch/data/members.json",
     "repo": "https://github.com/xyquadrat/polyring"
 }


### PR DESCRIPTION
This PR inlines the `members.json` into the polyring embed. This allows us to directly render instead of first making an HTTP request. 

Here are the Ligthhouse metrics (performance section) before:

![before](https://user-images.githubusercontent.com/16067344/221968078-660b0760-fa9b-4144-9ee7-65a3fc2e66f7.png)

...and after:

![after](https://user-images.githubusercontent.com/16067344/221968114-58a6caa7-b01d-4249-880e-d2033538c66a.png)

We could also remove the following line from `.eleventy.js`:

```js
config.addPassthroughCopy('src/data/members.json')
```

But there could still be some websites that rely on it (and I guess it's also helpful to have if somebody wants to create a completely customized webring banner and just load the raw data), so I've left it there for now.

One added benefit is also that we minify the `members.json` now, though that probably just saves a few bytes.
