### PR TITLE
Update feed URL for Jonas in members.json

### DIFF
--- a/src/data/members.json
+++ b/src/data/members.json
@@ -17,7 +17,7 @@
     {
         "title": "Jonas",
         "url": "https://log.jnsmr.ch/",
-        "feed": "https://log.jnsmr.ch/feed.xml"
+        "feed": "https://log.jnsmr.ch/post/feed.xml"
     },
     {
         "title": "Amos Herz",


### PR DESCRIPTION
feed url that only includes posts, i.e. ignores meta pages like `/about`