### PR TITLE
Update domain for Mark

### DIFF
--- a/src/data/members.json
+++ b/src/data/members.json
@@ -26,8 +26,8 @@
     },
     {
         "title": "Mark Csurgay",
-        "url": "https://markc.su",
-        "feed": "https://markc.su/posts/index.xml"
+        "url": "https://rkma.dev",
+        "feed": "https://rkma.dev/posts/index.xml"
     },
     {
         "title": "joniii",


### PR DESCRIPTION
Have to update my domain away from markc.su as I won't be able to prolong it after September. Opted for rkma.dev for now.